### PR TITLE
Fix wrong label file allocation for evaluation

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,21 +56,22 @@ def test(ppt_assistant, args):
             if args.resume:
 
                 if args.tf and os.path.exists(args.user_path+f'PPT_Pred_File/{set_name}/{args.exp_name}_{sess_id}_{turn_id}.pptx'):
-
                     print('Exists!')
                     continue 
                 if args.sess and os.path.exists(args.user_path+f'PPT_Pred_File/{set_name}/{args.exp_name}_{sess_id}_{len(session)-1}.pptx'):
                     print('Exists!')
                     continue 
             turn_id, instruction, label_api, base_ppt_path, label_ppt_path, api_lack_base_ppt_path, api_lack_label_ppt_path = turn
-            if turn_id == 0 and args.sess:
-                if args.api_lack:
-                    ppt_assistant.load_ppt(args.user_path+api_lack_base_ppt_path)
-                    label_file = api_lack_label_ppt_path
-                else:
-                    ppt_assistant.load_ppt(args.user_path+base_ppt_path)
-                    label_file = label_ppt_path
+
+            if args.api_lack:
+                ppt_assistant.load_ppt(args.user_path+api_lack_base_ppt_path)
+                label_file = api_lack_label_ppt_path
+            else:
+                ppt_assistant.load_ppt(args.user_path+base_ppt_path)
+                label_file = label_ppt_path
+
             splitted_instruction = instruction.split("##")[0]
+
             if args.tf:
                 if args.api_lack:
                     ppt_assistant.load_ppt(args.user_path+api_lack_base_ppt_path)


### PR DESCRIPTION
Discovered that when testing LLMs in session mode, the original code would set the label file for turn 0 as the label file for all turns. This is wrong as the label file should be the last turn.

My solution to fix was to follow the same label file allocation as the turn-based implementation. This ensures that the final turn (the only turn evaluated for session-based) will have the correct label file.